### PR TITLE
added bios enablement test

### DIFF
--- a/sev_component_test/component_tests.py
+++ b/sev_component_test/component_tests.py
@@ -726,6 +726,8 @@ def check_bios_enablement():
     '''
     Find in SEV/SME encryption is enabled in bios by looking at dmesg for notice.
     Will only appear on 1.51 fw or newer. If message doesn't appear then test passes.
+    Test will only appear in results if test fails, since the test could pass if dmesg is emptied
+    or if an old fw is installed.
     '''
     # Turns true if test passes
     test_result = False
@@ -734,9 +736,9 @@ def check_bios_enablement():
     # Expected test result
     expectation = "No notice (SEV enabled in BIOS)"
     # Will change to what the test finds
-    found_result = "EMPTY"
+    found_result = None
     # Command being used
-    command = "grep -w 'memory encryption'"
+    command = "grep -w 'memory encryption not enabled by BIOS'"
     try:
         # Read using dmesg
         dmesg_read = subprocess.run(

--- a/sev_component_test/component_tests.py
+++ b/sev_component_test/component_tests.py
@@ -721,3 +721,46 @@ def test_all_ovmf_paths(system_os:string, min_commit_date):
             paths_found.append(path_components)
 
     return one_path_true, paths_found
+
+def check_bios_enablement():
+    '''
+    Find in SEV/SME encryption is enabled in bios by looking at dmesg for notice.
+    Will only appear on 1.51 fw or newer. If message doesn't appear then test passes.
+    '''
+    # Turns true if test passes
+    test_result = False
+    # Name of component being tested
+    component = "BIOS enablement"
+    # Expected test result
+    expectation = "No notice (SEV enabled in BIOS)"
+    # Will change to what the test finds
+    found_result = "EMPTY"
+    # Command being used
+    command = "grep -w 'memory encryption'"
+    try:
+        # Read using dmesg
+        dmesg_read = subprocess.run(
+            "dmesg", shell=True, check=True, capture_output=True)
+        # Grep for error message
+        test_string_raw = subprocess.run(command, shell=True,
+                                         input=dmesg_read.stdout, check=True, capture_output=True)
+        # Grab the test string
+        test_string = test_string_raw.stdout.decode('utf-8').strip()
+        # If the test string appears, assume SME is disabled in BIOS
+        if test_string:
+            # Grab error message and return test result
+            division_string = test_string.split(":")
+            found_result = ':'.join(division_string[-2:]).strip()
+        return component, command, found_result, expectation, test_result
+    except (subprocess.CalledProcessError) as err:
+        # Error in subprocess, print warning message
+        if err.stderr.decode("utf-8").strip():
+            ovmf_shared_functions.print_warning_message(
+                component, err.stderr.decode("utf-8").strip())
+        # BIOS message not found, SEV probably enabled in BIOS. This means the test passes,
+        # Or the dmesg message is unavailable on current fw.
+        elif err.returncode == 1 and not err.stderr.decode("utf-8").strip():
+            found_result = ''
+            test_result = True
+        # Return results
+        return component, command, found_result, expectation, test_result

--- a/sev_component_test/sev_component_test.py
+++ b/sev_component_test/sev_component_test.py
@@ -90,7 +90,8 @@ def check_system_support_test(sme_enabled, non_verbose, system_os, stop_failure)
     # Tests to be run
     running_tests = {
         component_tests.find_cpuid_support: (system_os, 'SEV'),
-        component_tests.check_virtualization: ()
+        component_tests.check_virtualization: (),
+        component_tests.check_bios_enablement: ()
     }
 
     if sme_enabled:
@@ -109,6 +110,10 @@ def check_system_support_test(sme_enabled, non_verbose, system_os, stop_failure)
     for test, components in running_tests.items():
         current_component, current_command, current_found_result,\
             current_expectation, current_test_result = test(*components)
+        # BIOS enablement test passes. No need to provide message if test passes. 
+        # If test fails, provide error message.
+        if test == component_tests.check_bios_enablement and current_test_result:
+            continue
         if not non_verbose:
             print_test_result(current_component, current_command,
                               current_found_result, current_expectation, current_test_result)


### PR DESCRIPTION
Test that checks for dmesg error saying that SEV/SME is not enabled in bios. Test appears in system set-up part of test. Test result will only show up if test fails, this is due to the fact that the message will only appear in FW newer to 1.51, so even if message does not appear, it doesn't mean that bios is set up correctly. 